### PR TITLE
jwtkeyをbyte配列に変換

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: user_DB
       TZ: Asia/Tokyo
-    ports:
-      - "4306:3306"
+    # ports:
+    #   - "4306:3306"
   user:
     build:
       context: .
@@ -22,9 +22,11 @@ services:
     tty: true
     environment:
       TZ: Asia/Tokyo
-    ports:
-      - "50051:50051"
-      
+  
+  grpcurl:
+    image: networld/grpcurl
+    command: /grpcurl -plaintext -d '{"name":"csacss", "email":"asxssscsac@csa.cs", "password":"cdscsacsa"}' -H "Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzc2MDEwNjksImlzcyI6InJlZnJlc2hUb2tlbiIsInN1YiI6IjI2In0.M_qe0xcjP7Oor1j450sAeOQ4-fcj2knV2shTbrdZCKQ" user:50051 user_grpc.UserService/Update
+    tty: true
 volumes:
   user-data:
     driver: local

--- a/src/middleware/jwt.go
+++ b/src/middleware/jwt.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (m *GoMiddleware) parseToken(t string) (int64, error) {
-	jwtkey := conf.C.Auth.Jwtkey
+	jwtkey := []byte(conf.C.Auth.Jwtkey)
 	var claims jwt.StandardClaims
 	_, err := jwt.ParseWithClaims(t, &claims, func(token *jwt.Token) (interface{}, error) {
 		return jwtkey, nil

--- a/src/user/delivery/grpc/user_handler.go
+++ b/src/user/delivery/grpc/user_handler.go
@@ -84,13 +84,13 @@ func (s *server) GetByID(ctx context.Context, in *user_grpc.ID) (*user_grpc.User
 }
 
 func (s *server) Update(ctx context.Context, in *user_grpc.UpdateReq) (*user_grpc.User, error) {
+	userID := ctx.Value("userID").(int64)
 	user := &models.User{
+		ID: userID
 		Name:     in.Name,
 		Email:    in.Email,
 		Password: in.Password,
 	}
-	userID := ctx.Value("userID").(int64)
-	user.ID = userID
 	if err := s.UUsecase.Update(ctx, user); err != nil {
 		return nil, err
 	}

--- a/src/user/usecase/jwt.go
+++ b/src/user/usecase/jwt.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (*userUsecase) GenerateTokenPair(id int64) (*models.TokenPair, error) {
-	jwtkey := conf.C.Auth.Jwtkey
+	jwtkey := []byte(conf.C.Auth.Jwtkey)
 	expSec := conf.C.Auth.TokenExpSec
 	rtExpSec := conf.C.Auth.RtExpSec
 	strID := strconv.FormatInt(id, 10)


### PR DESCRIPTION
# WHY
jwtkeyがinvalid keyになっていたので対応
# WHAT
バイト配列に変換